### PR TITLE
Remove timed close of autocomplete

### DIFF
--- a/modules/components/tag-input.ts
+++ b/modules/components/tag-input.ts
@@ -401,10 +401,6 @@ export class TagInputComponent extends TagInputAccessor implements OnInit {
      * @name blur
      */
     public blur(): void {
-        if (this.autocomplete) {
-            setTimeout(() => this.dropdown.hide(), 150);
-        }
-
         this.onBlur.emit(this.inputForm.value.value);
     }
 


### PR DESCRIPTION
Autocomplete does not need to be hidden manually after 150ms, since closes automatically on key up.
Further, if a click is too slow (e.g. touch events on iPhone, slow mouse clicks..) the value will applied now. If the click was too slow, the dropdown closed too early and no value was applied.