### PR TITLE
Experimental feature: retrieve autocomplete items from an Observable (ex http.get())

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,9 +368,7 @@ public requestAutocompleteItems = (text: string): Observable<Response> => {
 
 ```html
 <tag-input [ngModel]="['@item']">
-    <tag-input-dropdown [autocompleteItems]="['iTem1']" 
-                        [autocompleteObservable]='requestAutocompleteItems'>
-    </tag-input-dropdown>
+    <tag-input-dropdown [autocompleteObservable]='requestAutocompleteItems'></tag-input-dropdown>
 </tag-input>
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a component for Angular >= 2. Design and API are blandly inspired by Angular Material's md-chips.
 
-**This component works in Angular 2.4.1**. If you have an issues, please do make sure you're not running a different version. Otherwise, please do open a new issue.
+**This component works in Angular 2.4.2**. If you have an issues, please do make sure you're not running a different version. Otherwise, please do open a new issue.
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -67,104 +67,161 @@ If you do use an array of objects, make sure you:
 
 #### Properties (optional)
 - **`placeholder`** - [**`?string`**]
+
 String that sets the placeholder of the input for entering new terms.
 
+
 - **`secondaryPlaceholder`** - [**`?string`**]
+
 String that sets the placeholder of the input for entering new terms when there are 0 items entered.
 
+
 - **`maxItems`** -  [**`?number`**]
+
 Sets the maximum number of items it is possible to enter.
 
+
 - **`readonly`** - [**`?boolean`**]
+
 Sets the tag input static, not allowing deletion/addition of the items entered.
 
+
 - **`separatorKeys`** - [**`?number[]`**] 
+
 Array of keyboard keys with which is possible to define the key for separating terms. By default, only Enter is the defined key.
 
+
 - **`transform`** - [**`?(item: string) => string`**]
+
 A function that takes as argument the value of an item, and returns a string with the new value when appended. If the method returns null/undefined/false, the item gets rejected.
 
+
 - **`inputId`** - [**`?string`**]
+
 Custom ID assigned to the input
 
+
 - **`inputClass`** - [**`?string`**]
+
 Custom class assigned to the input
 
+
 - **`clearOnBlur`** - [**`?boolean`**]
+
 If set to true, it will clear the form's text on blur events
 
+
 - **`hideForm`** - [**`?number`**]
+
 If set to true, will remove the form from the component
 
+
 - **`onTextChangeDebounce`** - [**`?number`**]
+
 Number of ms for debouncing the `onTextChange` event (defaults to `250`)
 
+
 - **`addOnBlur`** - [**`?boolean`**]
+
 If set to `true`, will add an item when the form is blurred (defaults to `false`)
 
+
 - **`addOnPaste`** - [**`?boolean`**]
+
 If set to `true`, will add items pasted into the form's input  (defaults to `false`)
 
+
 - **`pasteSplitPattern`** - [**`?string`**]
+
 Pattern used with the native method split() to separate patterns in the string pasted (defaults to `,`)
 
+
 - **`blinkIfDupe`** - [**`?boolean`**]
+
 If a duplicate item gets added, this will blink - giving the user a visual cue of where it is located (defaults to `true`)
 
+
 - **`removable`** - [**`?boolean`**]
+
 If set to `false`, it will not be possible to remove tags (defaults to `true`)
 
+
 - **`editable`** (experimental) - [**`?boolean`**]
+
 If set to `true`, it will be possible to edit the display value of the tags (defaults to `false`)
 
+
 - **`allowDupes`** - [**`?boolean`**]
+
 If set to `true`, it will be possible to add tags with the same value (defaults to `false`)
 
 
 ##### Validation (optional)
 - **`validators`** - [**`?Validators[]`**] 
+
 An array of Validators (custom or Angular's) that will validate the tag before adding it to the list of items. It is possible to use multiple validators.
+
 
 - **`errorMessages`** - [**`?Object{error: message}`**]
 An object whose key is the name of the error (ex. required) and the value is the message you want to display to your users
 
 ##### Autocomplete (optional)
 - **`onlyFromAutocomplete`** - [**`?boolean`**]
+
 If set to `true`, it will be possible to add new items only from the autocomplete dropdown
+
 
 ##### Tags as Objects (optional)
 - **`identifyBy`** - [**`?any`**]
+
 Any value you want your tag object to be defined by (defaults to `value`)
+
 
 - **`displayBy`** - [**`?string`**] 
 The string displayed in a tag object (defaults to `display`)
 
 #### Outputs (optional)
 - **`onAdd`** - [**`?onAdd($event: string)`**]
+
 Event fired when an item has been added
 
+
 - **`onRemove`** - [**`?onRemove($event: string)`**]
+
 Event fired when an item has been removed
+
 
 - **`onSelect`** - [**`?onSelect($event: string)`**]
 Event fired when an item has been selected
 
+
 - **`onFocus`** - [**`?onFocus($event: string)`**]
+
 Event fired when the input is focused - will return current input value
 
+
 - **`onBlur`** - [**`?onBlur($event: string)`**]
+
 Event fired when the input is blurred - will return current input value
 
+
 - **`onTextChange`** - [**`?onTextChange($event: string)`**]
+
 Event fired when the input value changes
 
+
 - **`onPaste`** - [**`?onPaste($event: string)`**]
+
 Event fired when the text is pasted into the input (only if `addOnPaste` is set to `true`)
 
+
 - **`onValidationError`** - [**`?onValidationError($event: string)`**]
+
 Event fired when the validation fails
 
+
 - **`onTagEdited`** - [**`?onTagEdited($event: TagModel)`**]
+
 Event fired when a tag is edited
 
 
@@ -172,21 +229,30 @@ Event fired when a tag is edited
 TagInputDropdownComponent is a proxy between `ng2-tag-input` and `ng2-material-dropdown`.
 
 - **`autocompleteObservable`** - [**`(text: string) => Observable<Response>`**] 
+
 A function that takes a string (current input value) and returns an Observable (ex. `http.get()`) with an array of items wit the same structure as `autocompleteItems` (see below). Make sure you retain the scope of your class or function when using this property.
- 
 It can be used to popuplate the autocomplete with items coming from an async request.
 
+
 - **`showDropdownIfEmpty`** - [**`?boolean`**]
+
 If set to `true`, the dropdown of the autocomplete will be shown as soon as the user focuses on the form
 
+
 - **`autocompleteItems`** - [**`?string[] | AutoCompleteModel[]`**]
+
 An array of items to populate the autocomplete dropdown
 
+
 - **`offset`** - [**`?string`**] 
+
 Offset to adjust the position of the dropdown with absolute values (defaults to `'0 0'`)
 
+
 - **`focusFirstElement`** - [**`?boolean`**] 
+
 If set to `true`, the first item of the dropdown will be automatically focused (defaults to `false`)
+
 
 The property `autocompleteItems` can be an array of strings or objects. Interface for `AutoCompleteModel` (just like `TagModel)` is:
 

--- a/README.md
+++ b/README.md
@@ -66,161 +66,161 @@ If you do use an array of objects, make sure you:
 **Notice**: the items provided to the model won't change, but the items added to the model will have the format { display, value }. If you do provide `identifyBy` and `displayBy`, these will be used as format for the user-entered tags.
 
 #### Properties (optional)
-- **`placeholder`** - [**`?string`**]
+**`placeholder`** - [**`?string`**]
 
 String that sets the placeholder of the input for entering new terms.
 
 
-- **`secondaryPlaceholder`** - [**`?string`**]
+**`secondaryPlaceholder`** - [**`?string`**]
 
 String that sets the placeholder of the input for entering new terms when there are 0 items entered.
 
 
-- **`maxItems`** -  [**`?number`**]
+**`maxItems`** -  [**`?number`**]
 
 Sets the maximum number of items it is possible to enter.
 
 
-- **`readonly`** - [**`?boolean`**]
+**`readonly`** - [**`?boolean`**]
 
 Sets the tag input static, not allowing deletion/addition of the items entered.
 
 
-- **`separatorKeys`** - [**`?number[]`**] 
+**`separatorKeys`** - [**`?number[]`**] 
 
 Array of keyboard keys with which is possible to define the key for separating terms. By default, only Enter is the defined key.
 
 
-- **`transform`** - [**`?(item: string) => string`**]
+**`transform`** - [**`?(item: string) => string`**]
 
 A function that takes as argument the value of an item, and returns a string with the new value when appended. If the method returns null/undefined/false, the item gets rejected.
 
 
-- **`inputId`** - [**`?string`**]
+**`inputId`** - [**`?string`**]
 
 Custom ID assigned to the input
 
 
-- **`inputClass`** - [**`?string`**]
+**`inputClass`** - [**`?string`**]
 
 Custom class assigned to the input
 
 
-- **`clearOnBlur`** - [**`?boolean`**]
+**`clearOnBlur`** - [**`?boolean`**]
 
 If set to true, it will clear the form's text on blur events
 
 
-- **`hideForm`** - [**`?number`**]
+**`hideForm`** - [**`?number`**]
 
 If set to true, will remove the form from the component
 
 
-- **`onTextChangeDebounce`** - [**`?number`**]
+**`onTextChangeDebounce`** - [**`?number`**]
 
 Number of ms for debouncing the `onTextChange` event (defaults to `250`)
 
 
-- **`addOnBlur`** - [**`?boolean`**]
+**`addOnBlur`** - [**`?boolean`**]
 
 If set to `true`, will add an item when the form is blurred (defaults to `false`)
 
 
-- **`addOnPaste`** - [**`?boolean`**]
+**`addOnPaste`** - [**`?boolean`**]
 
 If set to `true`, will add items pasted into the form's input  (defaults to `false`)
 
 
-- **`pasteSplitPattern`** - [**`?string`**]
+**`pasteSplitPattern`** - [**`?string`**]
 
 Pattern used with the native method split() to separate patterns in the string pasted (defaults to `,`)
 
 
-- **`blinkIfDupe`** - [**`?boolean`**]
+**`blinkIfDupe`** - [**`?boolean`**]
 
 If a duplicate item gets added, this will blink - giving the user a visual cue of where it is located (defaults to `true`)
 
 
-- **`removable`** - [**`?boolean`**]
+**`removable`** - [**`?boolean`**]
 
 If set to `false`, it will not be possible to remove tags (defaults to `true`)
 
 
-- **`editable`** (experimental) - [**`?boolean`**]
+**`editable`** (experimental) - [**`?boolean`**]
 
 If set to `true`, it will be possible to edit the display value of the tags (defaults to `false`)
 
 
-- **`allowDupes`** - [**`?boolean`**]
+**`allowDupes`** - [**`?boolean`**]
 
 If set to `true`, it will be possible to add tags with the same value (defaults to `false`)
 
 
 ##### Validation (optional)
-- **`validators`** - [**`?Validators[]`**] 
+**`validators`** - [**`?Validators[]`**] 
 
 An array of Validators (custom or Angular's) that will validate the tag before adding it to the list of items. It is possible to use multiple validators.
 
 
-- **`errorMessages`** - [**`?Object{error: message}`**]
+**`errorMessages`** - [**`?Object{error: message}`**]
 An object whose key is the name of the error (ex. required) and the value is the message you want to display to your users
 
 ##### Autocomplete (optional)
-- **`onlyFromAutocomplete`** - [**`?boolean`**]
+**`onlyFromAutocomplete`** - [**`?boolean`**]
 
 If set to `true`, it will be possible to add new items only from the autocomplete dropdown
 
 
 ##### Tags as Objects (optional)
-- **`identifyBy`** - [**`?any`**]
+**`identifyBy`** - [**`?any`**]
 
 Any value you want your tag object to be defined by (defaults to `value`)
 
 
-- **`displayBy`** - [**`?string`**] 
+**`displayBy`** - [**`?string`**] 
 The string displayed in a tag object (defaults to `display`)
 
 #### Outputs (optional)
-- **`onAdd`** - [**`?onAdd($event: string)`**]
+**`onAdd`** - [**`?onAdd($event: string)`**]
 
 Event fired when an item has been added
 
 
-- **`onRemove`** - [**`?onRemove($event: string)`**]
+**`onRemove`** - [**`?onRemove($event: string)`**]
 
 Event fired when an item has been removed
 
 
-- **`onSelect`** - [**`?onSelect($event: string)`**]
+**`onSelect`** - [**`?onSelect($event: string)`**]
 Event fired when an item has been selected
 
 
-- **`onFocus`** - [**`?onFocus($event: string)`**]
+**`onFocus`** - [**`?onFocus($event: string)`**]
 
 Event fired when the input is focused - will return current input value
 
 
-- **`onBlur`** - [**`?onBlur($event: string)`**]
+**`onBlur`** - [**`?onBlur($event: string)`**]
 
 Event fired when the input is blurred - will return current input value
 
 
-- **`onTextChange`** - [**`?onTextChange($event: string)`**]
+**`onTextChange`** - [**`?onTextChange($event: string)`**]
 
 Event fired when the input value changes
 
 
-- **`onPaste`** - [**`?onPaste($event: string)`**]
+**`onPaste`** - [**`?onPaste($event: string)`**]
 
 Event fired when the text is pasted into the input (only if `addOnPaste` is set to `true`)
 
 
-- **`onValidationError`** - [**`?onValidationError($event: string)`**]
+**`onValidationError`** - [**`?onValidationError($event: string)`**]
 
 Event fired when the validation fails
 
 
-- **`onTagEdited`** - [**`?onTagEdited($event: TagModel)`**]
+**`onTagEdited`** - [**`?onTagEdited($event: TagModel)`**]
 
 Event fired when a tag is edited
 
@@ -228,28 +228,28 @@ Event fired when a tag is edited
 ## API for TagInputDropdownComponent
 TagInputDropdownComponent is a proxy between `ng2-tag-input` and `ng2-material-dropdown`.
 
-- **`autocompleteObservable`** - [**`(text: string) => Observable<Response>`**] 
+**`autocompleteObservable`** - [**`(text: string) => Observable<Response>`**] 
 
 A function that takes a string (current input value) and returns an Observable (ex. `http.get()`) with an array of items wit the same structure as `autocompleteItems` (see below). Make sure you retain the scope of your class or function when using this property.
 It can be used to popuplate the autocomplete with items coming from an async request.
 
 
-- **`showDropdownIfEmpty`** - [**`?boolean`**]
+**`showDropdownIfEmpty`** - [**`?boolean`**]
 
 If set to `true`, the dropdown of the autocomplete will be shown as soon as the user focuses on the form
 
 
-- **`autocompleteItems`** - [**`?string[] | AutoCompleteModel[]`**]
+**`autocompleteItems`** - [**`?string[] | AutoCompleteModel[]`**]
 
 An array of items to populate the autocomplete dropdown
 
 
-- **`offset`** - [**`?string`**] 
+**`offset`** - [**`?string`**] 
 
 Offset to adjust the position of the dropdown with absolute values (defaults to `'0 0'`)
 
 
-- **`focusFirstElement`** - [**`?boolean`**] 
+**`focusFirstElement`** - [**`?boolean`**] 
 
 If set to `true`, the first item of the dropdown will be automatically focused (defaults to `false`)
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ If you do use an array of objects, make sure you:
 
 **Notice**: the items provided to the model won't change, but the items added to the model will have the format { display, value }. If you do provide `identifyBy` and `displayBy`, these will be used as format for the user-entered tags.
 
+
+
 #### Properties (optional)
 **`placeholder`** - [**`?string`**]
 
@@ -156,6 +158,7 @@ If set to `true`, it will be possible to edit the display value of the tags (def
 If set to `true`, it will be possible to add tags with the same value (defaults to `false`)
 
 
+
 ##### Validation (optional)
 **`validators`** - [**`?Validators[]`**] 
 
@@ -165,10 +168,13 @@ An array of Validators (custom or Angular's) that will validate the tag before a
 **`errorMessages`** - [**`?Object{error: message}`**]
 An object whose key is the name of the error (ex. required) and the value is the message you want to display to your users
 
+
+
 ##### Autocomplete (optional)
 **`onlyFromAutocomplete`** - [**`?boolean`**]
 
 If set to `true`, it will be possible to add new items only from the autocomplete dropdown
+
 
 
 ##### Tags as Objects (optional)
@@ -179,6 +185,8 @@ Any value you want your tag object to be defined by (defaults to `value`)
 
 **`displayBy`** - [**`?string`**] 
 The string displayed in a tag object (defaults to `display`)
+
+
 
 #### Outputs (optional)
 **`onAdd`** - [**`?onAdd($event: string)`**]

--- a/README.md
+++ b/README.md
@@ -66,89 +66,127 @@ If you do use an array of objects, make sure you:
 **Notice**: the items provided to the model won't change, but the items added to the model will have the format { display, value }. If you do provide `identifyBy` and `displayBy`, these will be used as format for the user-entered tags.
 
 #### Properties (optional)
-- **`placeholder`** - [**`?string`**] - String that sets the placeholder of the input for entering new terms.
+- **`placeholder`** - [**`?string`**]
+String that sets the placeholder of the input for entering new terms.
 
-- **`secondaryPlaceholder`** - [**`?string`**] - String that sets the placeholder of the input for entering new terms when there are 0 items entered.
+- **`secondaryPlaceholder`** - [**`?string`**]
+String that sets the placeholder of the input for entering new terms when there are 0 items entered.
 
-- **`maxItems`** -  [**`?number`**] - Sets the maximum number of items it is possible to enter.
+- **`maxItems`** -  [**`?number`**]
+Sets the maximum number of items it is possible to enter.
 
-- **`readonly`** - [**`?boolean`**] - Sets the tag input static, not allowing deletion/addition of the items entered.
+- **`readonly`** - [**`?boolean`**]
+Sets the tag input static, not allowing deletion/addition of the items entered.
 
-- **`separatorKeys`** - [**`?number[]`**] - Array of keyboard keys with which is possible to define the key for separating terms. By default, only Enter is the defined key.
+- **`separatorKeys`** - [**`?number[]`**] 
+Array of keyboard keys with which is possible to define the key for separating terms. By default, only Enter is the defined key.
 
-- **`transform`** - [**`?(item: string) => string`**] - a function that takes as argument the value of an item, and returns a string with the new value when appended. If the method returns null/undefined/false, the item gets rejected.
+- **`transform`** - [**`?(item: string) => string`**]
+A function that takes as argument the value of an item, and returns a string with the new value when appended. If the method returns null/undefined/false, the item gets rejected.
 
-- **`inputId`** - [**`?string`**] - custom ID assigned to the input
+- **`inputId`** - [**`?string`**]
+Custom ID assigned to the input
 
-- **`inputClass`** - [**`?string`**] - custom class assigned to the input
+- **`inputClass`** - [**`?string`**]
+Custom class assigned to the input
 
-- **`clearOnBlur`** - [**`?boolean`**] - if set to true, it will clear the form's text on blur events
+- **`clearOnBlur`** - [**`?boolean`**]
+If set to true, it will clear the form's text on blur events
 
-- **`hideForm`** - [**`?number`**] - if set to true, will remove the form from the component
+- **`hideForm`** - [**`?number`**]
+If set to true, will remove the form from the component
 
-- **`onTextChangeDebounce`** - [**`?number`**] - number of ms for debouncing the `onTextChange` event (defaults to `250`)
+- **`onTextChangeDebounce`** - [**`?number`**]
+Number of ms for debouncing the `onTextChange` event (defaults to `250`)
 
-- **`addOnBlur`** - [**`?boolean`**] - if set to true, will add an item when the form is blurred (defaults to `false`)
+- **`addOnBlur`** - [**`?boolean`**]
+If set to `true`, will add an item when the form is blurred (defaults to `false`)
 
-- **`addOnPaste`** - [**`?boolean`**] - if set to true, will add items pasted into the form's input  (defaults to `false`)
+- **`addOnPaste`** - [**`?boolean`**]
+If set to `true`, will add items pasted into the form's input  (defaults to `false`)
 
-- **`pasteSplitPattern`** - [**`?string`**] - pattern used with the native method split() to separate patterns in the string pasted (defaults to `,`)
+- **`pasteSplitPattern`** - [**`?string`**]
+Pattern used with the native method split() to separate patterns in the string pasted (defaults to `,`)
 
-- **`blinkIfDupe`** - [**`?boolean`**] - if a duplicate item gets added, this will blink - giving the user a visual cue of where it is located (defaults to `true`)
+- **`blinkIfDupe`** - [**`?boolean`**]
+If a duplicate item gets added, this will blink - giving the user a visual cue of where it is located (defaults to `true`)
 
-- **`removable`** - [**`?boolean`**] - if set to `false`, it will not be possible to remove tags (defaults to `true`)
+- **`removable`** - [**`?boolean`**]
+If set to `false`, it will not be possible to remove tags (defaults to `true`)
 
-- **`editable`** (experimental) - [**`?boolean`**] - if set to `true`, it will be possible to edit the display value of the tags (defaults to `false`)
+- **`editable`** (experimental) - [**`?boolean`**]
+If set to `true`, it will be possible to edit the display value of the tags (defaults to `false`)
 
-- **`allowDupes`** - [**`?boolean`**] - if set to `true`, it will be possible to add tags with the same value (defaults to `false`)
+- **`allowDupes`** - [**`?boolean`**]
+If set to `true`, it will be possible to add tags with the same value (defaults to `false`)
 
 
 ##### Validation (optional)
-- **`validators`** - [**`?Validators[]`**] - an array of Validators (custom or Angular's) that will validate the tag before adding it to the list of items. It is possible to use multiple validators.
+- **`validators`** - [**`?Validators[]`**] 
+An array of Validators (custom or Angular's) that will validate the tag before adding it to the list of items. It is possible to use multiple validators.
 
-- **`errorMessages`** - [**`?Object{error: message}`**] - an object whose key is the name of the error (ex. required) and the value is the message you want to display to your users
+- **`errorMessages`** - [**`?Object{error: message}`**]
+An object whose key is the name of the error (ex. required) and the value is the message you want to display to your users
 
 ##### Autocomplete (optional)
-- **`onlyFromAutocomplete`** - [**`?boolean`**] - if true, it will be possible to add new items only from the autocomplete dropdown
+- **`onlyFromAutocomplete`** - [**`?boolean`**]
+If set to `true`, it will be possible to add new items only from the autocomplete dropdown
 
 ##### Tags as Objects (optional)
-- **`identifyBy`** - [**`?any`**] - any value you want your tag object to be defined by (defaults to `value`)
+- **`identifyBy`** - [**`?any`**]
+Any value you want your tag object to be defined by (defaults to `value`)
 
-- **`displayBy`** - [**`?string`**] - the string displayed in a tag object (defaults to `display`)
+- **`displayBy`** - [**`?string`**] 
+The string displayed in a tag object (defaults to `display`)
 
 #### Outputs (optional)
-- **`onAdd`** - [**`?onAdd($event: string)`**] - event fired when an item has been added
+- **`onAdd`** - [**`?onAdd($event: string)`**]
+Event fired when an item has been added
 
-- **`onRemove`** - [**`?onRemove($event: string)`**] - event fired when an item has been removed
+- **`onRemove`** - [**`?onRemove($event: string)`**]
+Event fired when an item has been removed
 
-- **`onSelect`** - [**`?onSelect($event: string)`**] - event fired when an item has been selected
+- **`onSelect`** - [**`?onSelect($event: string)`**]
+Event fired when an item has been selected
 
-- **`onFocus`** - [**`?onFocus($event: string)`**] - event fired when the input is focused - will return current input value
+- **`onFocus`** - [**`?onFocus($event: string)`**]
+Event fired when the input is focused - will return current input value
 
-- **`onBlur`** - [**`?onBlur($event: string)`**] - event fired when the input is blurred - will return current input value
+- **`onBlur`** - [**`?onBlur($event: string)`**]
+Event fired when the input is blurred - will return current input value
 
-- **`onTextChange`** - [**`?onTextChange($event: string)`**] - event fired when the input value changes
+- **`onTextChange`** - [**`?onTextChange($event: string)`**]
+Event fired when the input value changes
 
-- **`onPaste`** - [**`?onPaste($event: string)`**] - event fired when the text is pasted into the input (only if `addOnPaste` is set to `true`)
+- **`onPaste`** - [**`?onPaste($event: string)`**]
+Event fired when the text is pasted into the input (only if `addOnPaste` is set to `true`)
 
-- **`onValidationError`** - [**`?onValidationError($event: string)`**] - event fired when the validation fails
+- **`onValidationError`** - [**`?onValidationError($event: string)`**]
+Event fired when the validation fails
 
-- **`onTagEdited`** - [**`?onTagEdited($event: TagModel)`**] - event fired when a tag is edited
+- **`onTagEdited`** - [**`?onTagEdited($event: TagModel)`**]
+Event fired when a tag is edited
 
 
 ## API for TagInputDropdownComponent
 TagInputDropdownComponent is a proxy between `ng2-tag-input` and `ng2-material-dropdown`.
 
-- **`autocompleteRequest`** - [**`(text: string) => Observable<Response>`**] - a function that takes a string (current input value) and returns an Observable (ex. `http.get()`)
- with an array of items wit the same structure as `autocompleteItems` (see below). It can be used to popuplate the autocomplete with items coming from an async request.
+- **`autocompleteObservable`** - [**`(text: string) => Observable<Response>`**] 
+A function that takes a string (current input value) and returns an Observable (ex. `http.get()`) with an array of items wit the same structure as `autocompleteItems` (see below). Make sure you retain the scope of your class or function when using this property.
+ 
+It can be used to popuplate the autocomplete with items coming from an async request.
 
-- **`showDropdownIfEmpty`** - [**`?boolean`**] - if true, the dropdown of the autocomplete will be shown as soon as the user focuses on the form
+- **`showDropdownIfEmpty`** - [**`?boolean`**]
+If set to `true`, the dropdown of the autocomplete will be shown as soon as the user focuses on the form
 
-- **`autocompleteItems`** - [**`?string[] | AutoCompleteModel[]`**] - an array of items to populate the autocomplete dropdown
+- **`autocompleteItems`** - [**`?string[] | AutoCompleteModel[]`**]
+An array of items to populate the autocomplete dropdown
 
-- **`offset`** - [**`?string`**] - offset to adjust the position of the dropdown with absolute values (defaults to `'0 0'`)
+- **`offset`** - [**`?string`**] 
+Offset to adjust the position of the dropdown with absolute values (defaults to `'0 0'`)
 
-- **`focusFirstElement`** - [**`?boolean`**] - if true, the first item of the dropdown will be automatically focused (defaults to `false`)
+- **`focusFirstElement`** - [**`?boolean`**] 
+If set to `true`, the first item of the dropdown will be automatically focused (defaults to `false`)
 
 The property `autocompleteItems` can be an array of strings or objects. Interface for `AutoCompleteModel` (just like `TagModel)` is:
 
@@ -240,6 +278,24 @@ This will accept items only from the autocomplete dropdown:
         <template let-item="item" let-index="index">
             {{ index }}: {{ item.display }}
         </template>
+    </tag-input-dropdown>
+</tag-input>
+```
+
+##### Populate items using an Observable
+```javascript
+public requestAutocompleteItems = (text: string): Observable<Response> => {
+    const url = `https://my.api.com/search?q=${text}`;
+    return this.http
+        .get(url)
+        .map(data => data.json());
+};
+```
+
+```html
+<tag-input [ngModel]="['@item']">
+    <tag-input-dropdown [autocompleteItems]="['iTem1']" 
+                        [autocompleteObservable]='requestAutocompleteItems'>
     </tag-input-dropdown>
 </tag-input>
 ```

--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ If you do use an array of objects, make sure you:
 ## API for TagInputDropdownComponent
 TagInputDropdownComponent is a proxy between `ng2-tag-input` and `ng2-material-dropdown`.
 
+- **`autocompleteRequest`** - [**`(text: string) => Observable<Response>`**] - a function that takes a string (current input value) and returns an Observable (ex. `http.get()`)
+ with an array of items wit the same structure as `autocompleteItems` (see below). It can be used to popuplate the autocomplete with items coming from an async request.
+
 - **`showDropdownIfEmpty`** - [**`?boolean`**] - if true, the dropdown of the autocomplete will be shown as soon as the user focuses on the form
 
 - **`autocompleteItems`** - [**`?string[] | AutoCompleteModel[]`**] - an array of items to populate the autocomplete dropdown

--- a/demo/app.ts
+++ b/demo/app.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import {BrowserModule} from '@angular/platform-browser';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { HttpModule } from '@angular/http';
 
 import { TagInputModule } from '../modules/ng2-tag-input.module';
 import { Home } from './home/home';
@@ -12,6 +13,7 @@ import { CommonModule } from '@angular/common';
     imports: [
         BrowserModule,
         CommonModule,
+        HttpModule,
         FormsModule,
         ReactiveFormsModule,
         TagInputModule

--- a/demo/home/home.html
+++ b/demo/home/home.html
@@ -77,7 +77,7 @@
                        [placeholder]="'Enter a new repo'"
                        [secondaryPlaceholder]="'Search in Github'"
                        [onlyFromAutocomplete]="true">
-                <tag-input-dropdown [autocompleteRequest]="requestAutocompleteItems">
+                <tag-input-dropdown [autocompleteObservable]="requestAutocompleteItems">
                     <template let-item="item" let-index="index">
                         {{ item.display }}
                     </template>

--- a/demo/home/home.html
+++ b/demo/home/home.html
@@ -77,9 +77,7 @@
                        [placeholder]="'Enter a new repo'"
                        [secondaryPlaceholder]="'Search in Github'"
                        [onlyFromAutocomplete]="true">
-                <tag-input-dropdown [autocompleteEndpointQueryParam]="'q'"
-                                    [autocompleteEndpointMapper]="autocompleteMapper"
-                                    [autocompleteEndpoint]="'https://api.github.com/search/repositories'">
+                <tag-input-dropdown [autocompleteRequest]="requestAutocompleteItems">
                     <template let-item="item" let-index="index">
                         {{ item.display }}
                     </template>

--- a/demo/home/home.html
+++ b/demo/home/home.html
@@ -72,6 +72,22 @@
         </div>
 
         <div>
+            <h3>Tags accepting only items from an autocomplete using a remote endpoint</h3>
+            <tag-input [ngModel]="[]"
+                       [placeholder]="'Enter a new repo'"
+                       [secondaryPlaceholder]="'Search in Github'"
+                       [onlyFromAutocomplete]="true">
+                <tag-input-dropdown [autocompleteEndpointQueryParam]="'q'"
+                                    [autocompleteEndpointMapper]="autocompleteMapper"
+                                    [autocompleteEndpoint]="'https://api.github.com/search/repositories'">
+                    <template let-item="item" let-index="index">
+                        {{ item.display }}
+                    </template>
+                </tag-input-dropdown>
+            </tag-input>
+        </div>
+
+        <div>
             <h3>An input which allows adding items by pressing the key "space" of your keyboard</h3>
             <tag-input [ngModel]="['@item']"
                        [inputClass]="'myinput'"

--- a/demo/home/home.ts
+++ b/demo/home/home.ts
@@ -21,6 +21,10 @@ export class Home {
         'item3'
     ];
 
+    autocompleteMapper(data: any) {
+        return data.items.map(item => item.full_name).slice(0, 10);
+    }
+
     public options = {
         readonly: undefined,
         placeholder: '+ Tag'

--- a/demo/home/home.ts
+++ b/demo/home/home.ts
@@ -4,11 +4,16 @@ import {
     FormControl
 } from '@angular/forms';
 
+import { Http, Response } from '@angular/http';
+import { Observable } from 'rxjs';
+
 @Component({
     selector: 'app',
     templateUrl: './home.html'
 })
 export class Home {
+    constructor(private http: Http) {}
+
     items = ['Javascript', 'Typescript'];
 
     itemsAsObjects = [{id: 0, name: 'Angular'}, {id: 1, name: 'React'}];
@@ -21,9 +26,12 @@ export class Home {
         'item3'
     ];
 
-    autocompleteMapper(data: any) {
-        return data.items.map(item => item.full_name).slice(0, 10);
-    }
+    public requestAutocompleteItems = (text: string): Observable<Response> => {
+        const url = `https://api.github.com/search/repositories?q=${text}`;
+        return this.http
+            .get(url)
+            .map(data => data.json().items.map(item => item.full_name));
+    };
 
     public options = {
         readonly: undefined,

--- a/modules/components/dropdown/tag-input-dropdown.component.ts
+++ b/modules/components/dropdown/tag-input-dropdown.component.ts
@@ -73,7 +73,7 @@ export class TagInputDropdown {
     /**
      * @name autocompleteEndpoint
      */
-    @Input() public autocompleteRequest: (text: string) => Observable<Response>;
+    @Input() public autocompleteObservable: (text: string) => Observable<Response>;
 
     /**
      * list of items that match the current value of the input (for autocomplete)
@@ -114,14 +114,14 @@ export class TagInputDropdown {
             this.show();
         });
 
-        if (this.autocompleteRequest) {
+        if (typeof this.autocompleteItems === Observable) {
             this.tagInput
                 .onTextChange
                 .filter((text: string) => !!text.trim().length)
                 .subscribe((text: string) => {
                     this.tagInput.isLoading = true;
 
-                    this.autocompleteRequest(text)
+                    this.autocompleteObservable(text)
                         .subscribe(data => {
                             this.tagInput.isLoading = false;
                             this.populateItemsFromHttp(data);

--- a/modules/components/dropdown/tag-input-dropdown.component.ts
+++ b/modules/components/dropdown/tag-input-dropdown.component.ts
@@ -114,19 +114,11 @@ export class TagInputDropdown {
             this.show();
         });
 
-        if (typeof this.autocompleteItems === Observable) {
+        if (this.autocompleteObservable) {
             this.tagInput
                 .onTextChange
                 .filter((text: string) => !!text.trim().length)
-                .subscribe((text: string) => {
-                    this.tagInput.isLoading = true;
-
-                    this.autocompleteObservable(text)
-                        .subscribe(data => {
-                            this.tagInput.isLoading = false;
-                            this.populateItemsFromHttp(data);
-                        });
-                });
+                .subscribe(this.getItemsFromObservable.bind(this));
         }
     }
 
@@ -268,14 +260,28 @@ export class TagInputDropdown {
     }
 
     /**
-     * @name populateItemsFromHttp
+     * @name populateItems
      * @param data
      */
-    private populateItemsFromHttp(data: any) {
+    private populateItems(data: any) {
         const terms = data.map(item => ({display: item, value: item}));
 
         this.autocompleteItems = [...this.autocompleteItems, ...terms];
 
         this.show();
+    }
+
+    /**
+     * @name getItemsFromObservable
+     * @param text
+     */
+    private getItemsFromObservable(text: string) {
+        this.tagInput.isLoading = true;
+
+        this.autocompleteObservable(text)
+            .subscribe(data => {
+                this.tagInput.isLoading = false;
+                this.populateItems(data);
+            });
     }
 }

--- a/modules/components/tag-input.template.html
+++ b/modules/components/tag-input.template.html
@@ -2,6 +2,7 @@
 <div ngClass="ng2-tag-input {{ theme }}"
      (click)="focus(true)"
      [attr.tabindex]="-1"
+     [class.ng2-tag-input--loading]="isLoading"
      [class.ng2-tag-input--invalid]="hasErrors()"
      [class.ng2-tag-input--focused]="isInputFocused()">
 
@@ -38,6 +39,8 @@
             [inputId]="inputId">
         </tag-input-form>
     </div>
+
+    <div class="progress-bar" *ngIf="isLoading"></div>
 </div>
 
 <!-- ERRORS -->

--- a/modules/components/tag-input.ts
+++ b/modules/components/tag-input.ts
@@ -307,6 +307,8 @@ export class TagInputComponent extends TagInputAccessor implements OnInit {
         change: <{(fun): any}[]>[]
     };
 
+    public isLoading: boolean = false;
+
     constructor(private renderer: Renderer) {
         super();
     }

--- a/modules/components/tag/tag-ripple.component.ts
+++ b/modules/components/tag/tag-ripple.component.ts
@@ -36,13 +36,10 @@ import {
         trigger('ink', [
             state('none', style({width: 0, opacity: 0})),
             transition('none => clicked', [
-                animate(200, keyframes([
-                    style({opacity: 1, offset: 0, width: 0, borderRadius: '0'}),
-                    style({opacity: 1, offset: 0.15, width: '15%'}),
-                    style({opacity: 1, offset: 0.35, width: '35%'}),
+                animate(300, keyframes([
+                    style({opacity: 1, offset: 0, width: '30%', borderRadius: '100%'}),
                     style({opacity: 1, offset: 0.5, width: '50%'}),
-                    style({opacity: 1, offset: 0.8, width: '80%'}),
-                    style({opacity: 1, offset: 1, width: '200%', borderRadius: '16px'})
+                    style({opacity: 0.5, offset: 1, width: '100%', borderRadius: '16px'})
                 ]))
             ])
         ])

--- a/modules/components/themes/_common.scss
+++ b/modules/components/themes/_common.scss
@@ -1,5 +1,7 @@
 // tag input
 
+@import "./_progress-bar.scss";
+
 .ng2-tag-input {
     display: flex;
     flex-direction: row;
@@ -11,6 +13,7 @@
     min-height: $container-height;
 
     cursor: text;
+    position: relative;
 }
 
 .ng2-tag-input:focus {
@@ -39,3 +42,8 @@
     border-bottom: 2px solid map-get($color-error, 'default');
 }
 
+.default.ng2-tag-input.ng2-tag-input--loading,
+.dark.ng2-tag-input.ng2-tag-input--loading,
+.minimal.ng2-tag-input.ng2-tag-input--loading {
+    border: none;
+}

--- a/modules/components/themes/_progress-bar.scss
+++ b/modules/components/themes/_progress-bar.scss
@@ -1,0 +1,31 @@
+.progress-bar, .progress-bar:before {
+    height: 2px;
+    width: 100%;
+    margin: 0;
+}
+
+.progress-bar {
+    background-color: map_get($color-focused, 'default');
+    display: flex;
+    position: absolute;
+    bottom: 0;
+}
+
+.progress-bar:before {
+    background-color: lighten(map_get($color-focused, 'default'), 20%);
+    content: '';
+    -webkit-animation: running-progress 2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+    animation: running-progress 2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+@-webkit-keyframes running-progress {
+    0% { margin-left: 0; margin-right: 100%; }
+    50% { margin-left: 25%; margin-right: 0; }
+    100% { margin-left: 100%; margin-right: 0; }
+}
+
+@keyframes running-progress {
+    0% { margin-left: 0; margin-right: 100%; }
+    50% { margin-left: 25%; margin-right: 0; }
+    100% { margin-left: 100%; margin-right: 0; }
+}

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "zone.js": "0.7.2"
   },
   "dependencies": {
-    "ng2-material-dropdown": "0.5.9"
+    "ng2-material-dropdown": "0.6.0"
   },
   "peerDependencies": {
     "@angular/core": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,15 @@
   "contributors": [],
   "license": "MIT",
   "devDependencies": {
-    "@angular/common": "2.4.1",
-    "@angular/compiler": "2.3.1",
-    "@angular/compiler-cli": "2.4.1",
-    "@angular/forms": "2.4.1",
-    "@angular/platform-browser": "2.4.1",
-    "@angular/platform-browser-dynamic": "2.4.1",
+    "@angular/core": "2.4.2",
+    "@angular/forms": "2.4.2",
+    "@angular/http": "2.4.2",
+    "rxjs": "5.0.1",
+    "@angular/common": "2.4.2",
+    "@angular/compiler": "2.4.2",
+    "@angular/compiler-cli": "2.4.2",
+    "@angular/platform-browser": "2.4.2",
+    "@angular/platform-browser-dynamic": "2.4.2",
     "@types/es6-collections": "^0.5.29",
     "@types/es6-shim": "0.0.31",
     "@types/jasmine": "^2.2.34",
@@ -63,16 +66,17 @@
     "webpack": "^1.14.0",
     "webpack-dev-server": "^1.16.2",
     "webpack-merge": "^0.8.4",
-    "zone.js": "0.6.23"
+    "zone.js": "0.7.2"
   },
   "dependencies": {
     "ng2-material-dropdown": "0.5.9"
   },
   "peerDependencies": {
-      "@angular/core": "2.4.1",
-      "@angular/forms": "2.4.1",
-      "@angular/http": "2.4.1",
-      "rxjs": "5.0.0-beta.12"
+    "@angular/core": "2.4.2",
+    "@angular/common": "2.4.2",
+    "@angular/forms": "2.4.2",
+    "@angular/http": "2.4.2",
+    "rxjs": "5.0.1"
   },
   "keywords": [
     "angular 2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@angular/common": "2.4.1",
     "@angular/compiler": "2.3.1",
     "@angular/compiler-cli": "2.4.1",
-    "@angular/core": "2.4.1",
     "@angular/forms": "2.4.1",
     "@angular/platform-browser": "2.4.1",
     "@angular/platform-browser-dynamic": "2.4.1",
@@ -50,10 +49,8 @@
     "node-sass": "^3.8.0",
     "postcss-loader": "^0.9.1",
     "precss": "^1.4.0",
-    "protractor": "^3.3.0",
     "raw-loader": "^0.5.1",
     "reflect-metadata": "0.1.2",
-    "rxjs": "5.0.0-beta.12",
     "sass-loader": "^3.2.3",
     "source-map-loader": "^0.1.5",
     "style-loader": "^0.13.1",
@@ -70,6 +67,12 @@
   },
   "dependencies": {
     "ng2-material-dropdown": "0.5.8"
+  },
+  "peerDependencies": {
+      "@angular/core": "2.4.1",
+      "@angular/forms": "2.4.1",
+      "@angular/http": "2.4.1",
+      "rxjs": "5.0.0-beta.12"
   },
   "keywords": [
     "angular 2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-tag-input",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Tag Input component for Angular 2",
   "scripts": {
     "prepublish": "npm run build",

--- a/tsconfig.aot.json
+++ b/tsconfig.aot.json
@@ -21,7 +21,8 @@
     },
     "angularCompilerOptions": {
         "genDir": "factories",
-        "useWebpackText": true
+        "useWebpackText": true,
+        "skipMetadataEmit" : true
     },
     "files": [
         "modules/ng2-tag-input.module.ts"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,8 @@ var webpackConfig = {
             "@angular/forms",
             "@angular/http",
             "rxjs/add/operator/debounceTime",
-            "rxjs/add/operator/map"
+            "rxjs/add/operator/map",
+            "rxjs/add/operator/filter"
         ],
         'ng2-tag-input': './modules/ng2-tag-input.module.ts'
     },
@@ -29,8 +30,7 @@ var webpackConfig = {
         "@angular/common": true,
         "@angular/forms": true,
         "@angular/http": true,
-        "rxjs/add/operator/debounceTime": true,
-        "rxjs/add/operator/map": true
+        "rxjs": true
     },
 
     plugins: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,14 @@ var autoprefixer = require('autoprefixer');
 // Webpack Config
 var webpackConfig = {
     entry: {
-        'vendor': ['@angular/core', '@angular/common', "@angular/forms", "rxjs/add/operator/debounceTime"],
+        'vendor': [
+            '@angular/core',
+            '@angular/common',
+            "@angular/forms",
+            "@angular/http",
+            "rxjs/add/operator/debounceTime",
+            "rxjs/add/operator/map"
+        ],
         'ng2-tag-input': './modules/ng2-tag-input.module.ts'
     },
 
@@ -21,7 +28,9 @@ var webpackConfig = {
         "@angular/core": true,
         "@angular/common": true,
         "@angular/forms": true,
-        "rxjs/add/operator/debounceTime": true
+        "@angular/http": true,
+        "rxjs/add/operator/debounceTime": true,
+        "rxjs/add/operator/map": true
     },
 
     plugins: [


### PR DESCRIPTION
The goal of this is to provide a quick way to populate the autocomplete items using an http request:
- will probably shift from initial implementation and let the user provide the Observable from the Http Request
- will need to provide an animation while the items are being fetched