### PR TITLE
provide 'last' variable to dropdown template

### DIFF
--- a/demo/home/home.html
+++ b/demo/home/home.html
@@ -90,6 +90,20 @@
         </div>
 
         <div>
+            <h3>Tags dropdown with last provided</h3>
+            <tag-input [ngModel]="[]"
+                       [placeholder]="'Enter a new repo'"
+                       [secondaryPlaceholder]="'Search in Github'"
+                       [onlyFromAutocomplete]="true">
+                <tag-input-dropdown [autocompleteObservable]="requestAutocompleteItems">
+                    <template let-item="item" let-index="index" let-last="last">
+                        ({{ index }}) {{ item.id }}: {{ item.value }} # {{ last }}
+                    </template>
+                </tag-input-dropdown>
+            </tag-input>
+        </div>
+
+        <div>
             <h3>An input which allows adding items by pressing the key "space" of your keyboard</h3>
             <tag-input [ngModel]="['@item']"
                        [inputClass]="'myinput'"

--- a/modules/components/dropdown/tag-input-dropdown.template.html
+++ b/modules/components/dropdown/tag-input-dropdown.template.html
@@ -2,7 +2,7 @@
     <ng2-dropdown-menu [focusFirstElement]="focusFirstElement"
                        [appendToBody]="appendToBody"
                        [offset]="offset">
-        <ng2-menu-item *ngFor="let item of items; let index = index;"
+        <ng2-menu-item *ngFor="let item of items; let index = index; let last = last"
                        [value]="item"
                        [ngSwitch]="!!templates.length">
 
@@ -12,7 +12,7 @@
 
             <template *ngSwitchDefault
                       [ngTemplateOutlet]="templates.first"
-                      [ngOutletContext]="{ item: item, index: index }">
+                      [ngOutletContext]="{ item: item, index: index, last: last }">
             </template>
         </ng2-menu-item>
     </ng2-dropdown-menu>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-tag-input",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Tag Input component for Angular 2",
   "scripts": {
     "prepublish": "npm run build",


### PR DESCRIPTION
### Use case
Fill `tag-input-dropdown` using a remote endpoint that sends a lot of data. We want to be able to request data by chunks. This can be achieve by putting a sentinel at the end of the template and use custom logic to request the next chunk from the endpoint. To do so, I need to know if the element is the last or not.

Of course, we can use `index` but using `last` seems more readable and keep the same api than `*ngFor`.

In my case it's useful because of the amount of data I need to manage.

Maybe there is a better way of doing this :-).

Thanks for your work.