### PR TITLE
Fix for ngc errors

### DIFF
--- a/modules/components/tag-input.template.html
+++ b/modules/components/tag-input.template.html
@@ -32,7 +32,6 @@
             (onFocus)="focus(false, true)"
             (onKeydown)="fireEvents('keydown', $event)"
             (onKeyup)="fireEvents('keyup', $event)"
-            (onKeypress)="handleKeyPress()"
             [validators]="validators"
             [hidden]="readonly || maxItemsReached"
             [placeholder]="items.length ? placeholder : secondaryPlaceholder"

--- a/modules/components/tag-input.ts
+++ b/modules/components/tag-input.ts
@@ -625,7 +625,7 @@ export class TagInputComponent extends TagInputAccessor implements OnInit {
      * @name maxItemsReached
      * @returns {boolean}
      */
-    private get maxItemsReached(): boolean {
+    public get maxItemsReached(): boolean {
         return this.maxItems !== undefined && this.items.length >= this.maxItems;
     }
 
@@ -736,5 +736,9 @@ export class TagInputComponent extends TagInputAccessor implements OnInit {
         if (this.hideForm) {
             this.inputForm.destroy();
         }
+    }
+
+    public handleKeyPress(): void {
+
     }
 }

--- a/modules/components/tag-input.ts
+++ b/modules/components/tag-input.ts
@@ -737,8 +737,4 @@ export class TagInputComponent extends TagInputAccessor implements OnInit {
             this.inputForm.destroy();
         }
     }
-
-    public handleKeyPress(): void {
-
-    }
 }

--- a/modules/components/tag/tag.component.ts
+++ b/modules/components/tag/tag.component.ts
@@ -165,7 +165,7 @@ export class TagComponent {
     /**
      * @name toggleEditMode
      */
-    public toggleEditMode(): void {
+    public toggleEditMode(event?: MouseEvent): void {
         if (this.editModeActivated) {
             this.storeNewValue();
         } else {
@@ -238,7 +238,7 @@ export class TagComponent {
      * @name isRippleVisible
      * @returns {boolean}
      */
-    private isRippleVisible(): boolean {
+    public isRippleVisible(): boolean {
         return !this.readonly && !this.editModeActivated;
     }
 }


### PR DESCRIPTION
Hey Gbuomprisco,

I can't compile my project with ngc. Errors:

- /ng2-tag-input/dist/modules/components/tag/tag.component.ngfactory.ts:543:44: Property 'isRippleVisible' is private and only accessible within class 'TagComponent'.
- /ng2-tag-input/dist/modules/components/tag/tag.component.ngfactory.ts:585:59: Supplied parameters do not match any signature of call target.
- /ng2-tag-input/dist/modules/components/tag-input.ngfactory.ts:831:67: Property 'maxItemsReached' is private and only accessible within class 'TagInputComponent'.
- /ng2-tag-input/dist/modules/components/tag-input.ngfactory.ts:891:48: Property 'handleKeyPress' does not exist on type 'TagInputComponent'.

I'm using Angular2 AoT compiler, these changes solves the errors above.