### PR TITLE
Add support to determine separator from `$event.key`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,14 @@ Sets the maximum number of items it is possible to enter.
 Sets the tag input static, not allowing deletion/addition of the items entered.
 
 
-**`separatorKeys`** - [**`?number[]`**]
+**`separatorKeyCodes`** - [**`?number[]`**]
 
 Array of keyboard keys with which is possible to define the key for separating terms. By default, only Enter is the defined key.
+
+
+**`separatorKeys`** - [**`?string[]`**]
+
+Array of input characters with which is possible to define the key for separating terms. Default is empty. Can use with `separatorKeyCodes`, either one method matched will trigger tag separation.
 
 
 **`transform`** - [**`?(item: string) => string`**]

--- a/modules/components/tag-input.ts
+++ b/modules/components/tag-input.ts
@@ -681,18 +681,14 @@ export class TagInputComponent extends TagInputAccessor implements OnInit {
         });
 
         listen.call(this, constants.KEYDOWN, ($event) => {
-            if (this.separatorKeys.indexOf($event.key) >= 0) {
-                $event.preventDefault();
-                this.addItem();
-            }
-        }, this.separatorKeys.length > 0);
+            const hasKeyCode = this.separatorKeyCodes.indexOf($event.keyCode) >= 0;
+            const hasKey = this.separatorKeys.indexOf($event.key) >= 0;
 
-        listen.call(this, constants.KEYDOWN, ($event) => {
-            if (this.separatorKeyCodes.indexOf($event.keyCode) >= 0) {
+            if (hasKeyCode || hasKey) {
                 $event.preventDefault();
                 this.addItem();
             }
-        }, this.separatorKeyCodes.length > 0);
+        }, this.separatorKeyCodes.length > 0 || this.separatorKeys.length > 0);
 
         // if the number of items specified in the model is > of the value of maxItems
         // degrade gracefully and let the max number of items to be the number of items in the model

--- a/modules/components/tag-input.ts
+++ b/modules/components/tag-input.ts
@@ -71,7 +71,14 @@ export class TagInputComponent extends TagInputAccessor implements OnInit {
      * @desc keyboard keys with which a user can separate items
      * @type {Array}
      */
-    @Input() public separatorKeys: number[] = [];
+    @Input() public separatorKeys: string[] = [];
+
+    /**
+     * @name separatorKeyCodes
+     * @desc keyboard key codes with which a user can separate items
+     * @type {Array}
+     */
+    @Input() public separatorKeyCodes: number[] = [];
 
     /**
      * @name placeholder
@@ -674,11 +681,18 @@ export class TagInputComponent extends TagInputAccessor implements OnInit {
         });
 
         listen.call(this, constants.KEYDOWN, ($event) => {
-            if (this.separatorKeys.indexOf($event.keyCode) >= 0) {
+            if (this.separatorKeys.indexOf($event.key) >= 0) {
                 $event.preventDefault();
                 this.addItem();
             }
         }, this.separatorKeys.length > 0);
+
+        listen.call(this, constants.KEYDOWN, ($event) => {
+            if (this.separatorKeyCodes.indexOf($event.keyCode) >= 0) {
+                $event.preventDefault();
+                this.addItem();
+            }
+        }, this.separatorKeyCodes.length > 0);
 
         // if the number of items specified in the model is > of the value of maxItems
         // degrade gracefully and let the max number of items to be the number of items in the model

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "ng2-material-dropdown": "0.7.4"
   },
   "peerDependencies": {
-    "@angular/core": "^2.4.0",
     "@angular/common": "^2.4.0",
+    "@angular/core": "^2.4.0",
     "@angular/forms": "^2.4.0",
     "rxjs": "^5.0.1"
   },


### PR DESCRIPTION
My requirement is to use any keys on keyboard. But the problem is `$event.keyCode` may faulty detect characters from other languages as the same code. Please review if I miss something.

Thank you.