### PR TITLE
Call onTouched when input form is blurred.

### DIFF
--- a/modules/components/helpers/accessor.ts
+++ b/modules/components/helpers/accessor.ts
@@ -12,7 +12,7 @@ export function isObject(obj: any): boolean {
 
 export class TagInputAccessor implements ControlValueAccessor {
     private _items: TagModel[] = [];
-    private _onTouchedCallback: (items: TagModel[]) => void;
+    private _onTouchedCallback: () => void;
     private _onChangeCallback: (items: TagModel[]) => void;
 
     /**
@@ -36,8 +36,8 @@ export class TagInputAccessor implements ControlValueAccessor {
         this._onChangeCallback(this._items);
     }
 
-    public onTouched(items) {
-        this._onTouchedCallback(items);
+    public onTouched() {
+        this._onTouchedCallback();
     }
 
     public writeValue(items: any[]) {

--- a/modules/components/tag-input.spec.ts
+++ b/modules/components/tag-input.spec.ts
@@ -68,6 +68,17 @@ describe('TagInputComponent', () => {
             expect(component.items.length).toEqual(2);
             expect(component.inputForm.input.nativeElement.getAttribute('placeholder')).toEqual('New Tag');
         }));
+
+        it('should be "touched" on blur', fakeAsync(() => {
+            const fixture: ComponentFixture<BasicTagInputComponent> = TestBed.createComponent(BasicTagInputComponent);
+            const component = <TagInputComponent>getComponent(fixture);
+            const onTouched = jasmine.createSpy('onTouched');
+
+            component.registerOnTouched(onTouched);
+            component.blur();
+
+            expect(onTouched).toHaveBeenCalled();
+        }));
     });
 
     describe('when a new item is added', () => {

--- a/modules/components/tag-input.ts
+++ b/modules/components/tag-input.ts
@@ -591,6 +591,7 @@ export class TagInputComponent extends TagInputAccessor implements OnInit {
             return;
         }
 
+        this.onTouched();
         this.selectedTag = undefined;
 
         if (applyFocus) {

--- a/modules/components/tag-input.ts
+++ b/modules/components/tag-input.ts
@@ -591,7 +591,6 @@ export class TagInputComponent extends TagInputAccessor implements OnInit {
             return;
         }
 
-        this.onTouched();
         this.selectedTag = undefined;
 
         if (applyFocus) {
@@ -608,6 +607,7 @@ export class TagInputComponent extends TagInputAccessor implements OnInit {
      * @name blur
      */
     public blur(): void {
+        this.onTouched();
         this.onBlur.emit(this.formValue);
     }
 


### PR DESCRIPTION
When the tag-input form is blurred, it still has the `ng-untouched` class.
This fix calls the `ControlValueAccessor` `onTouched` callback on blur to
set the state to 'touched' and thereby set the `ng-touched` class.