### PR TITLE
1.2.9 Bug fixes & mixed R/W tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.2.9
+
+### Breaking Changes
+- `readonly` is not part of the inputs, and is now a property that needs to be added to each tag in order to make it readonly
+
+### Bug fixes
+- removing tag should not trigger `onSelect`
+- OnRemoving does not trigger by backspace and drag remove
+- Added max-width for very long tags, and ellipsis at the end
+
 ## 1.2.3
 
 ### Features

--- a/demo/home/home.html
+++ b/demo/home/home.html
@@ -235,8 +235,11 @@
 
         <div>
             <h3>Disabled tag input</h3>
+
+            Disable: <input type="checkbox" [(ngModel)]="disabled" />
+
             <tag-input [ngModel]="items"
-                       [disabled]="true">
+                       [disabled]="disabled">
             </tag-input>
         </div>
 

--- a/demo/home/home.html
+++ b/demo/home/home.html
@@ -3,14 +3,14 @@
         <div>
             <h3>Simple Input with two items</h3>
             <tag-input [(ngModel)]="items"
+                       (onSelect)="onSelect($event)"
                        [modelAsStrings]="true">
             </tag-input>
         </div>
 
         <div>
-            <h3>Simple Input with two items as objects</h3>
+            <h3>Partially editable input with two items as objects</h3>
             <tag-input [(ngModel)]="itemsAsObjects"
-                       (onAdd)="onAdd($event)"
                        [identifyBy]="'id'"
                        [displayBy]="'name'"></tag-input>
         </div>
@@ -39,7 +39,7 @@
 
         <div>
             <h3>A read-only tag input</h3>
-            <tag-input [ngModel]="['Javascript', 'Typescript']" [readonly]="true"></tag-input>
+            <tag-input [ngModel]="[{display: 'Javascript', readonly: true}]"></tag-input>
         </div>
 
         <div>
@@ -77,9 +77,9 @@
                                     [displayBy]="'value'"
                                     [identifyBy]="'id'"
                                     [autocompleteItems]="autocompleteItemsAsObjects">
-                    <template let-item="item" let-index="index">
+                    <ng-template let-item="item" let-index="index">
                         ({{ index }}) {{ item.id }}: {{ item.value }}
-                    </template>
+                    </ng-template>
                 </tag-input-dropdown>
             </tag-input>
         </div>
@@ -88,15 +88,16 @@
             <h3>Tags accepting only items from an autocomplete using a remote endpoint</h3>
             <tag-input [ngModel]="[]"
                        [placeholder]="'Enter a new repo'"
+                       [onTextChangeDebounce]="2000"
                        [secondaryPlaceholder]="'Search in Github'"
                        [onlyFromAutocomplete]="true">
                 <tag-input-dropdown [autocompleteObservable]="requestAutocompleteItems">
-                    <template let-item="item" let-index="index">
+                    <ng-template let-item="item" let-index="index">
                         {{ item.display }}
-                    </template>
+                    </ng-template>
                 </tag-input-dropdown>
             </tag-input>
-        </div>
+        </div >
 
         <div>
             <h3>Tags dropdown with last provided</h3>
@@ -105,9 +106,9 @@
                        [secondaryPlaceholder]="'Search in Github'"
                        [onlyFromAutocomplete]="true">
                 <tag-input-dropdown [autocompleteObservable]="requestAutocompleteItems">
-                    <template let-item="item" let-index="index" let-last="last">
+                    <ng-template let-item="item" let-index="index" let-last="last">
                         ({{ index }}) {{ item.id }}: {{ item.value }} # {{ last }}
-                    </template>
+                    </ng-template>
                 </tag-input-dropdown>
             </tag-input>
         </div>
@@ -128,7 +129,7 @@
                        [modelAsStrings]="true"
                        #input
                        (onTextChange)="onTextChange($event)">
-                <template item-template let-item="item" let-index="index">
+                <ng-template item-template let-item="item" let-index="index">
                     <span>
                         item: {{ item }}
                     </span>
@@ -136,20 +137,20 @@
                     <span (click)="input.removeItem(item, index)" class="ng2-tag__remove-button">
                         x
                     </span>
-                </template>
+                </ng-template>
             </tag-input>
         </div>
 
         <div>
             <h3>Input with custom item template and custom dropdown item template</h3>
             <tag-input [ngModel]="['@item']">
-                <template let-item="item">
+                <ng-template let-item="item">
                     tag: {{ item }}
-                </template>
+                </ng-template>
                 <tag-input-dropdown [autocompleteItems]="autocompleteItemsAsObjects">
-                    <template let-item="item" let-index="index">
+                    <ng-template let-item="item" let-index="index">
                         dropdown: {{ item }}
-                    </template>
+                    </ng-template>
                 </tag-input-dropdown>
             </tag-input>
         </div>
@@ -268,6 +269,7 @@
         <div>
         <h3>Confirm adding and removing tags with Observables</h3>
         <tag-input [ngModel]="['item1']"
+                   [dragZone]="'zone1'"
                    [modelAsStrings]="true"
                    [onRemoving]="onRemoving"
                    [onAdding]="onAdding">

--- a/demo/home/home.ts
+++ b/demo/home/home.ts
@@ -15,6 +15,8 @@ import 'rxjs/add/operator/filter';
 export class Home {
     constructor(private http: Http) {}
 
+    disabled = true;
+
     items = ['Javascript', 'Typescript'];
 
     inputText = 'text';

--- a/demo/home/home.ts
+++ b/demo/home/home.ts
@@ -19,7 +19,7 @@ export class Home {
 
     inputText = 'text';
 
-    itemsAsObjects = [{id: 0, name: 'Angular', extra: 0}, {id: 1, name: 'React', extra: 1}];
+    itemsAsObjects = [{id: 0, name: 'Angular', readonly: true}, {id: 1, name: 'React'}];
 
     autocompleteItems = ['Item1', 'item2', 'item3'];
 

--- a/modules/components/tag-input-form/tag-input-form.template.html
+++ b/modules/components/tag-input-form/tag-input-form.template.html
@@ -14,7 +14,7 @@
            [attr.placeholder]="placeholder"
            [attr.aria-label]="placeholder"
            [attr.tabindex]="tabindex"
-           [attr.disabled]="disabled"
+           [attr.disabled]="disabled ? disabled : null"
 
            (focus)="onFocus.emit($event)"
            (blur)="onBlur.emit($event)"

--- a/modules/components/tag-input-form/tag-input-form.template.html
+++ b/modules/components/tag-input-form/tag-input-form.template.html
@@ -5,7 +5,7 @@
            type="text"
            class="ng2-tag-input__text-input"
            autocomplete="off"
-           tabindex="0"
+           tabindex="{{ disabled ? -1 : 0 }}"
 
            [(ngModel)]="inputText"
            [formControlName]="'item'"

--- a/modules/components/tag-input.template.html
+++ b/modules/components/tag-input.template.html
@@ -39,7 +39,6 @@
              [@flyInOut]="'in'"
              [hasRipple]="ripple"
              [index]="i"
-             [readonly]="readonly"
              [removable]="removable"
              [editable]="editable"
              [displayBy]="displayBy"

--- a/modules/components/tag-input.ts
+++ b/modules/components/tag-input.ts
@@ -514,7 +514,7 @@ export class TagInputComponent extends TagInputAccessor implements OnInit {
      * @param emit
      */
     public selectItem(item: TagModel, emit = true): void {
-        if (typeof item !== 'string' && item.readonly) {
+        if (!item || typeof item !== 'string' && item.readonly) {
             return;
         }
 

--- a/modules/components/tag-input.ts
+++ b/modules/components/tag-input.ts
@@ -514,7 +514,8 @@ export class TagInputComponent extends TagInputAccessor implements OnInit {
      * @param emit
      */
     public selectItem(item: TagModel, emit = true): void {
-        if (!item || typeof item !== 'string' && item.readonly) {
+        const isReadonly = item && typeof item !== 'string' && item.readonly;
+        if (isReadonly) {
             return;
         }
 

--- a/modules/components/tag/tag-component.style.scss
+++ b/modules/components/tag/tag-component.style.scss
@@ -7,6 +7,10 @@
     z-index: 1;
 }
 
+:host {
+    max-width: 400px;
+}
+
 :host.blink {
     -webkit-animation: blink 0.3s normal forwards ease-in-out;
     animation: blink 0.3s normal forwards ease-in-out;
@@ -26,6 +30,13 @@
     user-select: none;
 }
 
-.inline {
-    display: inline;
+.tag-wrapper {
+    flex-direction: row;
+    display: flex;
+}
+
+.tag__text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }

--- a/modules/components/tag/tag.component.ts
+++ b/modules/components/tag/tag.component.ts
@@ -17,6 +17,7 @@ import { TagRipple } from '../tag';
 // angular universal hacks
 /* tslint:disable-next-line */
 const KeyboardEvent = (global as any).KeyboardEvent;
+const MouseEvent = (global as any).MouseEvent;
 
 // mocking navigator
 const navigator = typeof window !== 'undefined' ? window.navigator : {
@@ -36,11 +37,6 @@ export class TagComponent {
      * @name model {TagModel}
      */
     @Input() public model: TagModel;
-
-    /**
-     * @name readonly {boolean}
-     */
-    @Input() public readonly: boolean;
 
     /**
      * @name removable {boolean}
@@ -113,6 +109,13 @@ export class TagComponent {
     @Output() public onTagEdited: EventEmitter<TagModel> = new EventEmitter<TagModel>();
 
     /**
+     * @name readonly {boolean}
+     */
+    public get readonly(): boolean {
+        return typeof this.model !== 'string' && this.model.readonly === true;
+    };
+
+    /**
      * @name editModeActivated
      * @type {boolean}
      */
@@ -153,7 +156,8 @@ export class TagComponent {
     /**
      * @name remove
      */
-    public remove(): void {
+    public remove($event: MouseEvent): void {
+        $event.stopPropagation();
         this.onRemove.emit(this);
     }
 

--- a/modules/components/tag/tag.template.html
+++ b/modules/components/tag/tag.template.html
@@ -15,10 +15,11 @@
         </ng-template>
     </div>
 
-    <div *ngSwitchCase="false">
+    <div *ngSwitchCase="false" class="tag-wrapper">
         <!-- TAG NAME -->
         <div [attr.contenteditable]="editModeActivated"
-             class="inline"
+             [attr.title]="getDisplayValue(model)"
+             class="tag__text inline"
              spellcheck="false"
              (keydown.enter)="disableEditMode($event)"
              (keydown.escape)="disableEditMode($event)"
@@ -31,7 +32,7 @@
         <delete-icon
             aria-label="Remove tag"
             role="button"
-            (click)="remove()"
+            (click)="remove($event)"
             *ngIf="isDeleteIconVisible()">
         </delete-icon>
     </div>

--- a/modules/core/styles/core/_mixins.scss
+++ b/modules/core/styles/core/_mixins.scss
@@ -136,6 +136,7 @@
     height: map-get($theme, 'height');
     transition: map-get($theme, 'transition');
     display: map-get($theme, 'display');
+    text-align: right;
 
     path {
         fill: map-get($theme, 'fill');

--- a/modules/core/styles/core/_mixins.scss
+++ b/modules/core/styles/core/_mixins.scss
@@ -1,5 +1,5 @@
 @mixin tag-input-theme($theme) {
-    display: flex;
+    display: block;
     flex-direction: row;
     flex-wrap: wrap;
     position: relative;

--- a/modules/core/styles/themes/_default-theme.scss
+++ b/modules/core/styles/themes/_default-theme.scss
@@ -48,7 +48,7 @@ $default-tag-theme: (
 );
 
 $default-icon-theme: (
-    width: 16px,
+    width: 20px,
     height: 16px,
 
     transition: all 0.15s,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-tag-input",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Tag Input component for Angular",
   "scripts": {
     "prepublish": "npm run clean && npm run build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-tag-input",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Tag Input component for Angular",
   "scripts": {
     "prepublish": "npm run clean && npm run build",


### PR DESCRIPTION
- `readonly` is not part of the inputs, and is now a property that needs to be added to each tag in order to make it readonly

Bug fixes
- removing tag should not trigger `onSelect`
- OnRemoving does not trigger by backspace and drag remove
- Added max-width for very long tags, and ellipsis at the end