### PR TITLE
update rxjs imports for treeshaking

### DIFF
--- a/demo/home/home.ts
+++ b/demo/home/home.ts
@@ -2,7 +2,7 @@ import {Component} from '@angular/core';
 
 import { FormControl } from '@angular/forms';
 import { Http, Response } from '@angular/http';
-import { Observable } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
 
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/filter';

--- a/modules/components/tag-input/tag-input.ts
+++ b/modules/components/tag-input/tag-input.ts
@@ -25,7 +25,7 @@ import {
 } from '@angular/forms';
 
 // rx
-import { Observable } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/filter';


### PR DESCRIPTION
Currently ng2-tag-input is importing the entire rxjs omnibus. Updated this so only Observable is imported. 